### PR TITLE
fix def disassociate_with_groups

### DIFF
--- a/towerlib/entities/host.py
+++ b/towerlib/entities/host.py
@@ -275,7 +275,7 @@ class Host(Entity):
         if not isinstance(groups, (list, tuple)):
             groups = [groups]
         groups = [group.lower() for group in groups]
-        host_group_names = [group.get('name').lower() for group in self.groups]
+        host_group_names = [group.name.lower() for group in self.groups]
         for group_name in groups:
             if group_name.lower() not in host_group_names:
                 raise InvalidGroup(group_name)


### PR DESCRIPTION
Before
\>>> example.associate_with_groups('no_cis')
... example.disassociate_with_groups('no_cis')
Traceback (most recent call last):
  File "<stdin>", line 2, in <module>
  File "towerlib/entities/host.py", line 278, in disassociate_with_groups
    host_group_names = [group.get('name').lower() for group in self.groups]
AttributeError: 'Group' object has no attribute 'get'
'Group' object has no attribute 'get'

\>>> 

After:

 \>>> example.associate_with_groups('no_cis')
True

\>>> example.disassociate_with_groups('no_cis')
[u'no_cis']
True

 \>>> 