### PR TITLE
HTTPS Support

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,4 +10,4 @@ Development Lead
 Contributors
 ------------
 
-None yet. Why not be the first?
+* Michael Wiley <michaeltwiley@gmail.com>

--- a/USAGE.rst
+++ b/USAGE.rst
@@ -45,10 +45,10 @@ To use towerlib in a project:
     tower = Tower('hostname', 'username', 'password')
 
     # using https with a valid cert (pick one)
-    tower = Tower('hostname', 'username', 'password', 'https')
+    tower = Tower('hostname', 'username', 'password', True)
 
     # using https with an invalid cert (pick one)
-    tower = Tower('hostname', 'username', 'password', 'https', False)
+    tower = Tower('hostname', 'username', 'password', True, False)
 
     # access hosts
     for host in tower.hosts:

--- a/USAGE.rst
+++ b/USAGE.rst
@@ -40,7 +40,15 @@ To use towerlib in a project:
 .. code-block:: python
 
     from towerlib import Tower
+
+    # using http (pick one)
     tower = Tower('hostname', 'username', 'password')
+
+    # using https with a valid cert (pick one)
+    tower = Tower('hostname', 'username', 'password', 'https')
+
+    # using https with an invalid cert (pick one)
+    tower = Tower('hostname', 'username', 'password', 'https', False)
 
     # access hosts
     for host in tower.hosts:

--- a/towerlib/towerlib.py
+++ b/towerlib/towerlib.py
@@ -108,11 +108,11 @@ class Tower(object):  # pylint: disable=too-many-public-methods
         self._logger = logging.getLogger(logger_name)
         self.secure = secure
         if self.secure is True:
-            protocol = 'https'
+            self.host = 'https://{host}'.format(host=host)
+            self.api = 'https://{host}/api/v2'.format(host=host)
         elif self.secure is False:
-            protocol = 'http'
-        self.host = '{protocol}://{host}'.format(protocol=protocol, host=host)
-        self.api = '{protocol}://{host}/api/v2'.format(protocol=protocol, host=host)
+            self.host = 'http://{host}'.format(host=host)
+            self.api = 'http://{host}/api/v2'.format(host=host)
         self.ssl_verify = ssl_verify
         self.username = username
         self.password = password

--- a/towerlib/towerlib.py
+++ b/towerlib/towerlib.py
@@ -120,7 +120,7 @@ class Tower(object):  # pylint: disable=too-many-public-methods
 
     def _setup_session(self):
         session = Session()
-        if self.secure is True):
+        if self.secure is True:
             session.verify = self.ssl_verify
         session.get(self.host)
         session.auth = (self.username, self.password)

--- a/towerlib/towerlib.py
+++ b/towerlib/towerlib.py
@@ -102,13 +102,17 @@ CONFIGURATION_STATE_CACHE = TTLCache(maxsize=1, ttl=CONFIGURATION_STATE_CACHING_
 class Tower(object):  # pylint: disable=too-many-public-methods
     """Models the api of ansible tower"""
 
-    def __init__(self, host, username, password, protocol='http', ssl_verify=True):
+    def __init__(self, host, username, password, secure=False, ssl_verify=True):
         logger_name = u'{base}.{suffix}'.format(base=LOGGER_BASENAME,
                                                 suffix=self.__class__.__name__)
         self._logger = logging.getLogger(logger_name)
+        self.secure = secure
+        if self.secure is True:
+            protocol = 'https'
+        elif self.secure is False:
+            protocol = 'http'
         self.host = '{protocol}://{host}'.format(protocol=protocol, host=host)
         self.api = '{protocol}://{host}/api/v2'.format(protocol=protocol, host=host)
-        self.protocol = protocol
         self.ssl_verify = ssl_verify
         self.username = username
         self.password = password
@@ -116,7 +120,7 @@ class Tower(object):  # pylint: disable=too-many-public-methods
 
     def _setup_session(self):
         session = Session()
-        if self.protocol == "https":
+        if self.secure is True):
             session.verify = self.ssl_verify
         session.get(self.host)
         session.auth = (self.username, self.password)

--- a/towerlib/towerlib.py
+++ b/towerlib/towerlib.py
@@ -102,18 +102,22 @@ CONFIGURATION_STATE_CACHE = TTLCache(maxsize=1, ttl=CONFIGURATION_STATE_CACHING_
 class Tower(object):  # pylint: disable=too-many-public-methods
     """Models the api of ansible tower"""
 
-    def __init__(self, host, username, password):
+    def __init__(self, host, username, password, protocol='http', ssl_verify=True):
         logger_name = u'{base}.{suffix}'.format(base=LOGGER_BASENAME,
                                                 suffix=self.__class__.__name__)
         self._logger = logging.getLogger(logger_name)
-        self.host = host
-        self.api = '{host}/api/v2'.format(host=host)
+        self.host = '{protocol}://{host}'.format(protocol=protocol, host=host)
+        self.api = '{protocol}://{host}/api/v2'.format(protocol=protocol, host=host)
+        self.protocol = protocol
+        self.ssl_verify = ssl_verify
         self.username = username
         self.password = password
         self.session = self._setup_session()
 
     def _setup_session(self):
         session = Session()
+        if self.protocol == "https":
+            session.verify = self.ssl_verify
         session.get(self.host)
         session.auth = (self.username, self.password)
         session.headers.update({'content-type': 'application/json'})


### PR DESCRIPTION
- Default "protocol" set to http to try not to break existing implementations.
- Default "ssl_verify"  set to True to encourage the use of valid certificates, but can easily be set to False to work around self signed certs and such.