### PR TITLE
Allow blank credential for create_project

### DIFF
--- a/towerlib/entities/organization.py
+++ b/towerlib/entities/organization.py
@@ -293,7 +293,7 @@ class Organization(Entity):  # pylint: disable=too-many-public-methods
         Args:
             name (str): The name of the project.
             description (str): The description of the project.
-            credential (str): The name of the credential to use for the project.
+            credential (str): The name of the credential to use for the project or '' if None.
             scm_url (str): The url of the scm.
             local_path (str): Local path (relative to PROJECTS_ROOT) containing playbooks and files for this project.
             custom_virtualenv (str): Local absolute file path containing a custom Python virtualenv to use.
@@ -313,9 +313,6 @@ class Organization(Entity):  # pylint: disable=too-many-public-methods
         """
         # Credential Type 2 = SCM
         url = '{api}/projects/'.format(api=self._tower.api)
-        credential_ = self.get_credential_by_name_with_type_id(credential, credential_type_id=2)
-        if not credential_:
-            raise InvalidCredential(credential)
         payload = {'name': name,
                    'description': description,
                    'scm_type': scm_type,
@@ -325,11 +322,15 @@ class Organization(Entity):  # pylint: disable=too-many-public-methods
                    'scm_branch': scm_branch,
                    'scm_clean': scm_clean,
                    'scm_delete_on_update': scm_delete_on_update,
-                   'credential': credential_.id,
                    'timeout': 0,
                    'organization': self.id,
                    'scm_update_on_launch': scm_update_on_launch,
                    'scm_update_cache_timeout': scm_update_cache_timeout}
+        if credential:
+            credential_ = self.get_credential_by_name_with_type_id(credential, credential_type_id=2)
+            payload['credential'] = credential_.id
+            if not credential_:
+                raise InvalidCredential(credential)
         response = self._tower.session.post(url, json=payload)
         if not response.ok:
             self._logger.error('Error creating project, response was: "%s"', response.text)

--- a/towerlib/entities/organization.py
+++ b/towerlib/entities/organization.py
@@ -328,9 +328,9 @@ class Organization(Entity):  # pylint: disable=too-many-public-methods
                    'scm_update_cache_timeout': scm_update_cache_timeout}
         if credential:
             credential_ = self.get_credential_by_name_with_type_id(credential, credential_type_id=2)
-            payload['credential'] = credential_.id
             if not credential_:
                 raise InvalidCredential(credential)
+            payload['credential'] = credential_.id
         response = self._tower.session.post(url, json=payload)
         if not response.ok:
             self._logger.error('Error creating project, response was: "%s"', response.text)


### PR DESCRIPTION
'credential' is not a required field when creating a project in tower and in my use case I do not need to use a credential. 

This PR adds a test to confirm a credential is passed before getting by name and adding to the payload. 
The test will pass for anything other than '' or None.

Examples:
org.create_project( 'project name', 'the description', '', 'http://some.url') - Now works and does not set a credential.
org.create_project( 'project name', 'the description', None, 'http://some.url') - Now works and does not set a credential.
org.create_project( 'project name', 'the description', 'Correct Creds', 'http://some.url') - Still works and sets a credential.

org.create_project( 'project name', 'the description', 'invalid Creds', 'http://some.url') - Still fails. 


At the next api change window, the credential parameter should be changed to have a default of None, but I didn't want to break backwards compatibility with this change. 