### PR TITLE
FIX: spelling error on JobEvent.event_level attribute

### DIFF
--- a/towerlib/entities/job.py
+++ b/towerlib/entities/job.py
@@ -143,7 +143,7 @@ class JobEvent(Entity):  # pylint: disable=too-many-public-methods
             integer: The level of the event.
 
         """
-        return self._data.get('event_data')
+        return self._data.get('event_level')
 
     @property
     def is_failed(self):


### PR DESCRIPTION
found in a debugging session, wondered why it does not display the event_level :)