### PR TITLE
Add trailing slash to few API endpoints to prevent extra redirection from Tower/AWX host

### DIFF
--- a/towerlib/entities/host.py
+++ b/towerlib/entities/host.py
@@ -306,7 +306,7 @@ class Host(Entity):
         Raises: None
 
         """
-        url = f'{self._tower.api}/hosts/{self.id}/ansible_facts'
+        url = f'{self._tower.api}/hosts/{self.id}/ansible_facts/'
         response = self._tower.session.get(url)
         if not response.ok:
             self._logger.error('Error finding ansible facts for %s.', self._data.get('name'))

--- a/towerlib/entities/job.py
+++ b/towerlib/entities/job.py
@@ -446,7 +446,7 @@ class JobRun(Entity):  # pylint: disable=too-many-public-methods
     # TOFIX add labels, model them and implement them here
 
     def _get_dynamic_value(self, variable):
-        url = f'{self._tower.api}/jobs/{self.id}'
+        url = f'{self._tower.api}/jobs/{self.id}/'
         response = self._tower.session.get(url)
         return response.json().get(variable) if response.ok else None
 
@@ -711,7 +711,7 @@ class WorkflowJobRun(JobRun):
     """Models the Workflow Job Run entity of ansible tower."""
 
     def _get_dynamic_value(self, variable):
-        url = f'{self._tower.api}/workflow_jobs/{self.id}'
+        url = f'{self._tower.api}/workflow_jobs/{self.id}/'
         response = self._tower.session.get(url)
         return response.json().get(variable) if response.ok else None
 


### PR DESCRIPTION
Urls without trailing slash get redirect from Tower host to url with it: https://docs.ansible.com/ansible-tower/3.8.4/html/towerapi/conventions.html . 

However if your Tower/AWX container runs on different port published (e.g. `-p 8088:8013`) you will get `Connection refused` because port that Tower/AWX actually listen to is unavailable from outside.

Tower/AWX itself always returns urls with trailing slash.

Connection refused example with cURL:
```bash
 curl -L -v --request GET \
  --url https://myhost/api/v2/hosts/1/ansible_facts \
  --header 'authorization: Basic mybase64' \
  --header 'content-type: application/json'

*   Trying ip:443...
* Connected to myhost (ip) port 443 (#0)
*  SSL certificate verify ok.
> GET /api/v2/hosts/1/ansible_facts HTTP/2
* Connection state changed (MAX_CONCURRENT_STREAMS == 128)!
< HTTP/2 301
< location: http://myhost:8013/api/v2/hosts/1/ansible_facts/
* Ignoring the response-body
* Connection #0 to host myhost left intact
* Issue another request to this URL: 'http://myhost:8013/api/v2/hosts/1/ansible_facts/'
*   Trying ip:8013...
* connect to ip port 8013 failed: Connection refused
* Failed to connect to myhost port 8013 after 45 ms: Connection refused
```

With towerlib it makes not possible to get job dynamic values:
```python
q = tower.get_job_by_id(1)
test = q.status # ConnectionError Exception here
```

I believe this redirect is redundant so I fixed all urls that I can find 🙂