### PR TITLE
Add default timeout for all requests

### DIFF
--- a/towerlib/towerlib.py
+++ b/towerlib/towerlib.py
@@ -111,10 +111,10 @@ class Tower:
                  password,
                  secure=False,
                  ssl_verify=True,
-                 timeout=5,
                  token=None,
                  pool_connections=HTTP_POOL_CONNECTIONS,
-                 pool_maxsize=HTTP_POOL_MAX_SIZE):
+                 pool_maxsize=HTTP_POOL_MAX_SIZE,
+                 timeout=5):
         self._logger = logging.getLogger(f'{LOGGER_BASENAME}.{self.__class__.__name__}')
         self.host = self._generate_host_name(host, secure)
         self.api = f'{self.host}/api/v2'


### PR DESCRIPTION
From the requests documentation:

> Most requests to external servers should have a timeout attached, in case the server is not responding in a timely manner. By default, requests do not time out unless a timeout value is set explicitly. Without a timeout, your code may hang for minutes or more.
> 
> The connect timeout is the number of seconds Requests will wait for your client to establish a connection to a remote machine (corresponding to the connect()) call on the socket. It’s a good practice to set connect timeouts to slightly larger than a multiple of 3, which is the default TCP packet retransmission window.