### PR TITLE
Support AAP 2.5+ by adding aap_environment flag to switch API endpoint

### DIFF
--- a/towerlib/towerlib.py
+++ b/towerlib/towerlib.py
@@ -118,7 +118,7 @@ class Tower:
                  aap_environment=False):
         self._logger = logging.getLogger(f'{LOGGER_BASENAME}.{self.__class__.__name__}')
         self.host = self._generate_host_name(host, secure)
-        self.api = f"{self.host}/api/controller/v2" if aap_environment else f"{self.host}/api/v2"
+        self.api = f'{self.host}/api/controller/v2' if aap_environment else f'{self.host}/api/v2'
         self.username = username
         self.password = password
         self.token = token

--- a/towerlib/towerlib.py
+++ b/towerlib/towerlib.py
@@ -114,10 +114,11 @@ class Tower:
                  token=None,
                  pool_connections=HTTP_POOL_CONNECTIONS,
                  pool_maxsize=HTTP_POOL_MAX_SIZE,
-                 timeout=5):
+                 timeout=5,
+                 aap_environment=False):
         self._logger = logging.getLogger(f'{LOGGER_BASENAME}.{self.__class__.__name__}')
         self.host = self._generate_host_name(host, secure)
-        self.api = f'{self.host}/api/v2'
+        self.api = f"{self.host}/api/controller/v2" if aap_environment else f"{self.host}/api/v2"
         self.username = username
         self.password = password
         self.token = token


### PR DESCRIPTION
### Changes

- New aap_environment flag in constructor to switch between /api/v2/ (default) and /api/controller/v2/ endpoints.
- Keeps backward compatibility with older Tower/AWX.

### Why

AAP 2.5 changed the API endpoint, breaking compatibility with current towerlib.